### PR TITLE
Introduce BindableBase to enable property changed notifications

### DIFF
--- a/WPFUtilities/BindableBase.cs
+++ b/WPFUtilities/BindableBase.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace WPFUtilities
+{
+    public class BindableBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public bool OnPropertyChanged(object oldValue, object newValue, [CallerMemberName]string? propertyName = null)
+        {
+            if (oldValue.Equals(newValue))
+            {
+                return false;
+            }
+
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Add base class for classes that need to invoke property changed notification.
Instead of using [Microsoft's proposed way of implementing `INotifyPropertyChanged`](https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-implement-property-change-notification?view=netframeworkdesktop-4.8), as we do it most of the times, I have added a condition that checks if the value of the property has changed or not before invoking `PropertyChanged` event to avoid unnecessary property changed events.
The `OnPropertyChanged` function also returns a boolean stating if the property has been changed or not.